### PR TITLE
Rename 'Postion' to 'Position'

### DIFF
--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLBinaryLiteral.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLBinaryLiteral.cs
@@ -8,10 +8,10 @@ namespace TSQL.Tokens
 	public class TSQLBinaryLiteral : TSQLLiteral
 	{
 		internal TSQLBinaryLiteral(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLCharacter.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLCharacter.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLCharacter : TSQLToken
 	{
 		internal TSQLCharacter(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Character = TSQLCharacters.Parse(text);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLComment.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLComment.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public abstract class TSQLComment : TSQLToken
 	{
 		internal protected TSQLComment(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLIdentifier.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLIdentifier.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLIdentifier : TSQLToken
 	{
 		internal TSQLIdentifier(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			if (Text.StartsWith("["))

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLKeyword.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLKeyword.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLKeyword : TSQLToken
 	{
 		internal TSQLKeyword(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Keyword = TSQLKeywords.Parse(text);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLLiteral.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLLiteral.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public abstract class TSQLLiteral : TSQLToken
 	{
 		internal protected TSQLLiteral(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLMoneyLiteral.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLMoneyLiteral.cs
@@ -8,10 +8,10 @@ namespace TSQL.Tokens
 	public class TSQLMoneyLiteral : TSQLLiteral
 	{
 		internal TSQLMoneyLiteral(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLMultilineComment.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLMultilineComment.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLMultilineComment : TSQLComment
 	{
 		internal TSQLMultilineComment(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Comment = Text.Substring(2, Text.Length - 4);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLNumericLiteral.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLNumericLiteral.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLNumericLiteral : TSQLLiteral
 	{
 		internal TSQLNumericLiteral(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLOperator.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLOperator.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLOperator : TSQLToken
 	{
 		internal TSQLOperator(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLSingleLineComment.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLSingleLineComment.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLSingleLineComment : TSQLComment
 	{
 		internal TSQLSingleLineComment(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Comment = Text.Substring(2);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLStringLiteral.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLStringLiteral.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLStringLiteral : TSQLLiteral
 	{
 		internal TSQLStringLiteral(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			// need to find unescaped value insides quote characters

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLSystemIdentifier.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLSystemIdentifier.cs
@@ -8,10 +8,10 @@ namespace TSQL.Tokens
 	public class TSQLSystemIdentifier : TSQLIdentifier
 	{
 		internal TSQLSystemIdentifier(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Identifier = TSQLIdentifiers.Parse(text);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLSystemVariable.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLSystemVariable.cs
@@ -8,10 +8,10 @@ namespace TSQL.Tokens
 	public class TSQLSystemVariable : TSQLVariable
 	{
 		internal TSQLSystemVariable(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 			Variable = TSQLVariables.Parse(text);

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLToken.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLToken.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public abstract class TSQLToken
 	{
 		internal protected TSQLToken(
-			int beginPostion,
+			int beginPosition,
 			string text)
 		{
-			BeginPostion = beginPostion;
+			BeginPosition = beginPosition;
 			if (text == null)
 			{
 				throw new ArgumentNullException("text");
@@ -16,7 +16,7 @@ namespace TSQL.Tokens
 			Text = text;
 		}
 
-		public int BeginPostion
+		public int BeginPosition
 		{
 			get;
 			private set;
@@ -26,7 +26,7 @@ namespace TSQL.Tokens
 		{
 			get
 			{
-				return BeginPostion + Length - 1;
+				return BeginPosition + Length - 1;
 			}
 		}
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLVariable.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLVariable.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLVariable : TSQLToken
 	{
 		internal TSQLVariable(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/TSQL_Parser/Tokens/TSQLWhitespace.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/TSQLWhitespace.cs
@@ -5,10 +5,10 @@ namespace TSQL.Tokens
 	public class TSQLWhitespace : TSQLToken
 	{
 		internal TSQLWhitespace(
-			int beginPostion,
+			int beginPosition,
 			string text) :
 			base(
-				beginPostion,
+				beginPosition,
 				text)
 		{
 

--- a/TSQL_Parser/Tests/Tokens/TokenComparisons.cs
+++ b/TSQL_Parser/Tests/Tokens/TokenComparisons.cs
@@ -51,7 +51,7 @@ namespace Tests.Tokens
 
 		public static void CompareTokens(TSQLToken expected, TSQLToken actual)
 		{
-			Assert.AreEqual(expected.BeginPostion, actual.BeginPostion, "Token begin position does not match.");
+			Assert.AreEqual(expected.BeginPosition, actual.BeginPosition, "Token begin position does not match.");
 			Assert.AreEqual(expected.EndPosition, actual.EndPosition, "Token end position does not match.");
 			Assert.AreEqual(expected.Text, actual.Text, "Token text does not match.");
             Assert.AreEqual(expected.GetType(), actual.GetType());


### PR DESCRIPTION
This is fixing all occurrences of 'Postion' to 'Position', which looks like a typo. Unfortunately, this is changing the name of a public field, so existing users of the library will need to fix their usages when they upgrade. It's probably better to fix such a typo sooner rather than later!

Thanks for considering this pull request.