### PR TITLE
#117 Case Expression trailing whitespace

### DIFF
--- a/TSQL_Parser/TSQL_Parser/Expressions/Parsers/TSQLCaseExpressionParser.cs
+++ b/TSQL_Parser/TSQL_Parser/Expressions/Parsers/TSQLCaseExpressionParser.cs
@@ -39,6 +39,10 @@ namespace TSQL.Expressions.Parsers
 
 			tokenizer.MoveNext();
 
+			TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+				tokenizer,
+				caseExpression.Tokens);
+
 			return caseExpression;
 		}
 	}

--- a/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
+++ b/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
@@ -8,6 +8,7 @@ using TSQL.Statements;
 using TSQL.Tokens;
 
 using Tests.Tokens;
+using TSQL.Expressions.Parsers;
 
 namespace Tests.Expressions
 {
@@ -80,6 +81,27 @@ namespace Tests.Expressions
 						new TSQLIdentifier(52, "abi")
 					},
 				tokens);
+		}
+
+		[TestCase(false, 30)]
+		[TestCase(true, 31)]
+		public void CaseExpression_Should_Include_TrailingWhitespace_If_Flag_Is_True(bool includeWhiteSpace, int expectedEndPosition)
+		{
+			const string sql =
+			//   0123456789012345678901234567890123456789
+				"CASE 1 WHEN 2 THEN 2 ELSE 3 END ";
+
+			TSQLTokenizer tokenizer = new TSQLTokenizer(sql)
+			{
+				IncludeWhitespace = includeWhiteSpace
+			};
+
+			Assert.IsTrue(tokenizer.MoveNext());
+
+			var expression = new TSQLCaseExpressionParser().Parse(tokenizer);
+			Assert.AreEqual(0, expression.BeginPosition);
+			Assert.AreEqual(expectedEndPosition, expression.EndPosition);
+
 		}
 	}
 }

--- a/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
+++ b/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
@@ -87,9 +87,8 @@ namespace Tests.Expressions
 		[TestCase(true, 31)]
 		public void CaseExpression_Should_Include_TrailingWhitespace_If_Flag_Is_True(bool includeWhiteSpace, int expectedEndPosition)
 		{
-			const string sql =
-			//   0123456789012345678901234567890123456789
-				"CASE 1 WHEN 2 THEN 2 ELSE 3 END ";
+			//                  0123456789012345678901234567890123456789
+			const string sql = "CASE 1 WHEN 2 THEN 2 ELSE 3 END ";
 
 			TSQLTokenizer tokenizer = new TSQLTokenizer(sql)
 			{


### PR DESCRIPTION
Trailing whitespaces were not included in the case expression when IncludeWhiteSpace=true. #117 
This leads to a failure when parsing this expression

```
ISNULL(CASE 1 WHEN 2 THEN 2 ELSE 3 END , 4)
```