### PR TITLE
#121 Parse nested case statements

### DIFF
--- a/TSQL_Parser/TSQL_Parser/Expressions/Parsers/TSQLCaseExpressionParser.cs
+++ b/TSQL_Parser/TSQL_Parser/Expressions/Parsers/TSQLCaseExpressionParser.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+using TSQL.Elements;
 using TSQL.Tokens;
 using TSQL.Tokens.Parsers;
 
@@ -22,21 +18,110 @@ namespace TSQL.Expressions.Parsers
 
 			caseExpression.Tokens.Add(tokenizer.Current);
 
-			TSQLTokenParserHelper.ReadUntilStop(
-				tokenizer,
-				caseExpression,
-				new List<TSQLFutureKeywords>() { },
-				new List<TSQLKeywords>() {
-					TSQLKeywords.END
-				},
-				lookForStatementStarts: false);
+			tokenizer.MoveNext();
 
-			// this is different than the other clauses because the
-			// stop word is still part of the expression instead of
-			// being part of the next expression or clause like in
-			// the other parsers
+			TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+				tokenizer,
+				caseExpression.Tokens);
+
+			var nextToken = tokenizer.Current ?? throw new TSQLParseException("CASE expression is incomplete. Expect WHEN or an input expression");
+
+			TSQLToken whenToken = null;
+
+			if (!nextToken.IsKeyword(TSQLKeywords.WHEN))
+			{
+				caseExpression.IsSimpleCaseExpression = true;
+				var valueExpr = new TSQLValueExpressionParser().Parse(tokenizer);
+				caseExpression.Tokens.AddRange(valueExpr.Tokens);
+
+				TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+					tokenizer,
+					caseExpression.Tokens);
+
+				whenToken = tokenizer.Current;
+			}
+			else
+			{
+				caseExpression.IsSimpleCaseExpression = false;
+				whenToken = nextToken;
+			}
+
+			if (!whenToken.IsKeyword(TSQLKeywords.WHEN))
+			{
+				throw new TSQLParseException("CASE expression is incorrect. It should have a WHEN keyword, instead we have: " + whenToken.Text);
+			}
+
+			// 'WHEN' keyword
+			caseExpression.Tokens.Add(whenToken);
+
+			do
+			{
+				if (!tokenizer.MoveNext())
+				{
+					throw new TSQLParseException("CASE expression is incomplete. After WHEN, there should be an expression");
+				}
+
+				TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+					tokenizer,
+					caseExpression.Tokens);
+
+				var whenExpr = new TSQLValueExpressionParser().Parse(tokenizer);
+				caseExpression.Tokens.AddRange(whenExpr.Tokens);
+
+				if (!tokenizer.Current.IsKeyword(TSQLKeywords.THEN))
+				{
+					throw new TSQLParseException(
+						"CASE expression is incomplete. After WHEN, there should be a THEN keyword");
+				}
+
+				// 'THEN' keyword
+				caseExpression.Tokens.Add(tokenizer.Current);
+
+				if (!tokenizer.MoveNext())
+				{
+					throw new TSQLParseException(
+						"CASE expression is incomplete. After THEN, there should be an expression");
+				}
+
+				TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+					tokenizer,
+					caseExpression.Tokens);
+
+				var thenExpr = new TSQLValueExpressionParser().Parse(tokenizer);
+				caseExpression.Tokens.AddRange(thenExpr.Tokens);
+
+			} while (tokenizer.Current.IsKeyword(TSQLKeywords.WHEN));
+
+			if (!tokenizer.Current.IsKeyword(TSQLKeywords.ELSE))
+			{
+				throw new TSQLParseException(
+					"CASE expression is incomplete. There should be an ELSE keyword");
+			}
+
 			caseExpression.Tokens.Add(tokenizer.Current);
 
+			if (!tokenizer.MoveNext())
+			{
+				throw new TSQLParseException(
+					"CASE expression incomplete. There should be an expression after ELSE keyword");
+			}
+
+			TSQLTokenParserHelper.ReadCommentsAndWhitespace(
+				tokenizer,
+				caseExpression.Tokens);
+
+			var elseExpr = new TSQLValueExpressionParser().Parse(tokenizer);
+			caseExpression.Tokens.AddRange(elseExpr.Tokens);
+
+			if (!tokenizer.Current.IsKeyword(TSQLKeywords.END))
+			{
+				throw new TSQLParseException("CASE expression incomplete. There should be an END keyword");
+			}
+
+			// 'END' keyword
+			caseExpression.Tokens.Add(tokenizer.Current);
+
+			// move past the END keyword
 			tokenizer.MoveNext();
 
 			TSQLTokenParserHelper.ReadCommentsAndWhitespace(
@@ -45,5 +130,12 @@ namespace TSQL.Expressions.Parsers
 
 			return caseExpression;
 		}
+
+		private TSQLToken ReadNextToken(ITSQLTokenizer tokenizer)
+		{
+			if (!tokenizer.MoveNext()) return null;
+			return tokenizer.Current;
+		}
+
 	}
 }

--- a/TSQL_Parser/TSQL_Parser/Expressions/TSQLCaseExpression.cs
+++ b/TSQL_Parser/TSQL_Parser/Expressions/TSQLCaseExpression.cs
@@ -6,6 +6,19 @@ using System.Threading.Tasks;
 
 namespace TSQL.Expressions
 {
+	/// <summary>
+	/// -- Simple CASE expression:
+	/// CASE input_expression
+	/// WHEN when_expression THEN result_expression [ ...n ]
+	/// [ ELSE else_result_expression ]
+	/// END
+	///
+	/// -- Searched CASE expression:
+	/// CASE
+	/// WHEN Boolean_expression THEN result_expression [ ...n ]
+	/// [ ELSE else_result_expression ]
+	/// END
+	/// </summary>
 	public class TSQLCaseExpression : TSQLExpression
 	{
 		public override TSQLExpressionType Type
@@ -15,5 +28,9 @@ namespace TSQL.Expressions
 				return TSQLExpressionType.Case;
 			}
 		}
+
+		public bool IsSimpleCaseExpression { get; set; }
 	}
+
+
 }

--- a/TSQL_Parser/TSQL_Parser/Expressions/TSQLCaseExpression.cs
+++ b/TSQL_Parser/TSQL_Parser/Expressions/TSQLCaseExpression.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TSQL.Expressions
 {
@@ -29,7 +26,19 @@ namespace TSQL.Expressions
 			}
 		}
 
+		public void AddWhenExpression(TSQLExpression when)
+		{
+			if (when == null) throw new ArgumentException("Should not be null", nameof(when));
+			if (when.Tokens.Count == 0) throw new ArgumentException("Should have tokens", nameof(when));
+
+			((List<TSQLExpression>)WhenExpressions).Add(when);
+		}
+
 		public bool IsSimpleCaseExpression { get; set; }
+
+		public TSQLExpression InputExpression { get; set; }
+
+		public IReadOnlyList<TSQLExpression> WhenExpressions { get; } = new List<TSQLExpression>();
 	}
 
 

--- a/TSQL_Parser/TSQL_Parser/TSQLParseException.cs
+++ b/TSQL_Parser/TSQL_Parser/TSQLParseException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace TSQL
+{
+    public class TSQLParseException: Exception
+    {
+        public TSQLParseException(string message): base(message)
+        {
+            
+        }
+    }
+}

--- a/TSQL_Parser/TSQL_Parser/TSQLParseException.cs
+++ b/TSQL_Parser/TSQL_Parser/TSQLParseException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using TSQL.Expressions;
 
 namespace TSQL
 {
@@ -6,7 +8,13 @@ namespace TSQL
     {
         public TSQLParseException(string message): base(message)
         {
-            
+
+        }
+
+        public TSQLParseException(string message, TSQLExpression expr) : base(
+            message + " \n..." + string.Join(" ", expr.Tokens.Select(t => t.Text)) + "[error]")
+        {
+
         }
     }
 }

--- a/TSQL_Parser/TSQL_Parser/TSQL_Parser.csproj
+++ b/TSQL_Parser/TSQL_Parser/TSQL_Parser.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Tokens\TSQLTokenExtensions.cs" />
     <Compile Include="TSQLFutureKeywords.cs" />
     <Compile Include="TSQLIdentifiers.cs" />
+    <Compile Include="TSQLParseException.cs" />
     <Compile Include="TSQLStatementReader.cs" />
     <Compile Include="TSQLStatementReader.IDisposable.cs">
       <DependentUpon>TSQLStatementReader.cs</DependentUpon>

--- a/TSQL_Parser/TSQL_Parser/Tokens/Parsers/TSQLTokenParserHelper.cs
+++ b/TSQL_Parser/TSQL_Parser/Tokens/Parsers/TSQLTokenParserHelper.cs
@@ -104,6 +104,12 @@ namespace TSQL.Tokens.Parsers
 				element.Tokens);
 		}
 
+		/// <summary>
+		/// Precondition: tokenizer.Current has not been consumed
+		/// Postcondition: tokenizer advanced if token consumed
+		/// </summary>
+		/// <param name="tokenizer"></param>
+		/// <param name="savedTokens"></param>
 		public static void ReadCommentsAndWhitespace(
 			ITSQLTokenizer tokenizer,
 			List<TSQLToken> savedTokens)

--- a/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
+++ b/TSQL_Parser/Tests/Expressions/CaseExpressionTests.cs
@@ -102,5 +102,26 @@ namespace Tests.Expressions
 			Assert.AreEqual(expectedEndPosition, expression.EndPosition);
 
 		}
+
+		[Test]
+		public void CaseExpression_Inside_CaseExpression()
+		{
+			const string sql = @"CASE 10
+WHEN 20 THEN 30
+ELSE CASE 40
+ WHEN 50 THEN 60
+ ELSE 70
+ END
+END";
+
+			TSQLTokenizer tokenizer = new TSQLTokenizer(sql);
+
+			Assert.IsTrue(tokenizer.MoveNext());
+
+			var expression = new TSQLCaseExpressionParser().Parse(tokenizer);
+			CollectionAssert.AllItemsAreNotNull(expression.Tokens);
+			Assert.AreEqual(0, expression.BeginPosition);
+
+		}
 	}
 }

--- a/TSQL_Parser/Tests/TestHelpers.cs
+++ b/TSQL_Parser/Tests/TestHelpers.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
+using TSQL.Expressions;
 
 namespace Tests
 {
@@ -13,32 +14,42 @@ namespace Tests
         public static void CompareArrays<T>(T[] expected, T[] actual)
         {
             Assert.AreEqual(
-                expected == null, 
-                actual == null, 
-                "Expected {0}null value and {1}null found.", 
-                expected == null ? "" : "not", 
+                expected == null,
+                actual == null,
+                "Expected {0}null value and {1}null found.",
+                expected == null ? "" : "not",
                 actual == null ? "" : "not");
 
             if (expected == null || actual == null)
                 return;
 
             Assert.AreEqual(
-                expected.LongLength, 
-                actual.LongLength, 
-                "Expected Length is {0} actual: {1}", 
-                expected.LongLength, 
+                expected.LongLength,
+                actual.LongLength,
+                "Expected Length is {0} actual: {1}",
+                expected.LongLength,
                 actual.LongLength);
 
             for (int i = 0; i < expected.Length; i++)
             {
                 Assert.AreEqual(
-                    expected[i], 
-                    actual[i], 
-                    "Values on index {0} are not equal. Expected {1} actual: {2}", 
-                    i, 
-                    expected[i], 
+                    expected[i],
+                    actual[i],
+                    "Values on index {0} are not equal. Expected {1} actual: {2}",
+                    i,
+                    expected[i],
                     actual[i]);
             }
+        }
+
+        /// <summary>
+        /// To aid debugging
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        public static string TokensAsText(this TSQLExpression expression)
+        {
+            return string.Join(" ", expression.Tokens.Select(t => t.Text));
         }
     }
 }


### PR DESCRIPTION
Parse CASE statements according to this grammar so that nested case statements are parsed correctly #121 

```
        /// -- Simple CASE expression:
	/// CASE input_expression
	/// WHEN when_expression THEN result_expression [ ...n ]
	/// [ ELSE else_result_expression ]
	/// END
	///
	/// -- Searched CASE expression:
	/// CASE
	/// WHEN Boolean_expression THEN result_expression [ ...n ]
	/// [ ELSE else_result_expression ]
	/// END
```

Throws a TSQLParseException indicating point of error if the syntax is not correct.

The `CaseExpression` has been fleshed out with InputExpression and WhenExpressions properties to aid in code generation.

Several tests have been added:
- CaseExpression_Else_Is_Optional
- CaseExpression_ParseException
- CaseExpression_Inside_CaseExpression
- CaseExpression_Trailing_Comments_Stress_Test

The is a known bug where the parser will parse `CASE WHEN END END` successfully. This will require additional validation in ValueExpressionParser.

